### PR TITLE
fix : 체험상세 데이터 로딩 완료 후 스크롤 초기화

### DIFF
--- a/src/app/activity/[id]/page.tsx
+++ b/src/app/activity/[id]/page.tsx
@@ -26,6 +26,12 @@ const ActivityDetail = () => {
   const { user, token } = useAuthStore();
 
   useEffect(() => {
+    if (!loading && activity) {
+      window.scrollTo(0, 0);
+    }
+  }, [loading, activity]);
+
+  useEffect(() => {
     if (!activityId) return;
 
     const loadActivity = async () => {


### PR DESCRIPTION
## 📌 관련 이슈

closes #146 

## 📝 구현 내용

서버에서 데이터를 가져오면서 이전 위치 기준으로 비슷한 위치를 보여주는것같습니다. 
훅 사용하여 데이터 로딩이 완료되고 자동으로 페이지를 맨 위로 스크롤하도록 코드 추가했습니다 


## 🔍 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분을 적어주세요 -->

체험 상세화면 진입시 동작 확인부탁드립니다. 