### PR TITLE
Feature/#151 side nav menu 프로필수정

### DIFF
--- a/src/app/(myPage)/_component/SideNavMenu.tsx
+++ b/src/app/(myPage)/_component/SideNavMenu.tsx
@@ -46,12 +46,13 @@ export async function ProfileImageUrl(file: File, token: string | null) {
 }
 
 export default function SideNavMenu() {
+  const { user } = useAuthStore();
   const { setImageurl } = useFixProfile();
   const pathname = usePathname(); // 현재 경로 가져오기
 
   const [profileImage, setProfileImage] = useState<ProfileImage>({
     file: null,
-    preview: '/icons/defaultuser_icon.svg',
+    preview: user?.profileImageUrl || '/icons/defaultuser_icon.svg',
   });
 
   const imageRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## 📌 관련 이슈

closes #151 

## 📝 구현 내용

기존에는 Header에 있는 프로필이미지와
마이페이지 SideNavMenu 프로필 이미지가 달라 

마이페이지 SideNaMenu가 Header이미지를 따르게 했습니다.

## 🔍 리뷰 포인트

<!-- 리뷰어가 중점적으로 봐주었으면 하는 부분을 적어주세요 -->

- [ ]
- [ ]

## 📸 스크린샷

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 테스트 체크리스트

<!-- 테스트 해봐야 하는 부분들을 적어주세요 -->

- [ ]
- [ ]

## 📊 성능 개선

<!-- 성능 개선 사항이 있다면 적어주세요 -->

## 🎸 기타

<!-- 기타 참고 사항이 있다면 적어주세요 -->
